### PR TITLE
Bugfix/link copied when click event assigned

### DIFF
--- a/src/scripts/reddit/copy-short-link.user.js
+++ b/src/scripts/reddit/copy-short-link.user.js
@@ -18,11 +18,6 @@ function doLog(message, formatting = []) {
   console.log(`%c[PurplProto -> Copy Short Link]%c: ${message}`, 'color: BlueViolet', 'color: unset', ...formatting);
 }
 
-// Check if we've added the short link button
-function isShortLinkAdded(menuElement) {
-  return menuElement.firstChild.textContent === 'Copy Short Link';
-}
-
 // Build short link
 function buildShortLink() {
   const postId = window.location.pathname.split('/')[4];
@@ -62,8 +57,11 @@ function addShortLinkToClipboard() {
     for (const mutation of mutationsList) {
       const menuElement = document.querySelector('[role="menu"]');
 
+      // Falsy when it's not the share menu, or if we've already added the shortlink button
+      // Need to check if we've already added because mutations can trigger multiple times
+      const isShareMenu = menuElement?.firstChild?.textContent?.toLowerCase() === 'copy link';
       const newElementsAdded = mutation.type === 'childList';
-      if (newElementsAdded && !!menuElement && !isShortLinkAdded(menuElement)) {
+      if (newElementsAdded && !!menuElement && isShareMenu) {
         doLog('%cwe found the menu', ['color: green']);
         prependShortLinkButton(menuElement);
       }

--- a/src/scripts/reddit/copy-short-link.user.js
+++ b/src/scripts/reddit/copy-short-link.user.js
@@ -49,7 +49,7 @@ function addShortLinkToClipboard() {
     const linkIcon = menuElement.firstChild.firstChild.cloneNode(true);
 
     // Add click handler
-    shortLinkButton.addEventListener('click', addShortLinkToClipboard());
+    shortLinkButton.addEventListener('click', addShortLinkToClipboard);
 
     // Modify the text, add the link icon and then prepend it to the menu
     shortLinkButton.textContent = 'Copy Short Link';


### PR DESCRIPTION
- Fixed issue where the short link is copied to the clipboard as soon as the click event is assigned to the button
- Fixed an issue with the script triggering when opening the Reddit coins menu. Now we check to see if we've found the share menu specifically